### PR TITLE
Fix Spelling of GitHub

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -51,7 +51,7 @@ People interested in our topics are welcome at our regular meetings.
 		<li><a href="mailto:presse@chaostreff-osnabrueck.de">Press requests</a></li>
 	</ul></dd>
 
-	<dt>Github</dt>
+	<dt>GitHub</dt>
 	<dd><a href="https://github.com/CTreffOS" rel="noreferer" target="_blank">github.com/CTreffOS</a></dd>
 
 	<dt>Jabber</dt>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ Interessierte sind bei unseren regelmäßigen Treffen jederzeit herzlich willkom
 		<li><a href="mailto:presse@chaostreff-osnabrueck.de">Presseanfragen</a></li>
 	</ul></dd>
 
-	<dt>Github</dt>
+	<dt>GitHub</dt>
 	<dd><a href="https://github.com/CTreffOS" rel="noreferer" target="_blank">github.com/CTreffOS</a></dd>
 
 	<dt>Jabber</dt>


### PR DESCRIPTION
This patch fixes the name GitHub. The official name is written with an uppercase “H” while the version on the current website used a lowercase letter.