### PR TITLE
Even Spacing in Footer

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -82,12 +82,12 @@ People interested in our topics are welcome at our regular meetings.
 
 <hr>
 
-<div align="left">
+<footer>
 <a href="site-notice-en.html">Site notice</a>
 <a href="privacy-policy-en.html">Privacy policy</a>
 <a href="legal-notice-en.html">Legal notice</a>
 <a href="donate-en.html">Donate</a>
-</div>
+</footer>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -86,12 +86,12 @@ Interessierte sind bei unseren regelmäßigen Treffen jederzeit herzlich willkom
 
 <hr>
 
-<div align="left">
+<footer>
 <a href="site-notice.html">Impressum</a>
 <a href="privacy-policy.html">Datenschutzerklärung</a>
 <a href="legal-notice.html">Rechtliche Hinweise</a>
 <a href="donate.html">Spenden</a>
-</div>
+</footer>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -53,7 +53,10 @@ body {
 	body {
 		font-size: 22px;
 	}
-
+	footer a {
+		display: block;
+		width: 90%
+	}
 }
 
 dt {
@@ -92,4 +95,10 @@ header img {
 .alert {
 	color: red;
 	font-weight: bold;
+}
+
+footer {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-evenly;
 }


### PR DESCRIPTION
This patch converts the footer to a flex-box with even spacing between link items instead of a continuous line of text. This provides a far better separation between the different items.

On small/mobile screens where the content is unlikely to fit, this will break down to display only one link per line providing more structure than a sometimes wrapped line.

---

On desktop

![Screenshot from 2023-01-29 13-57-06](https://user-images.githubusercontent.com/1008395/215327950-166527d4-b06e-43a5-a8ee-5cede33010ba.png)


On mobile

<img src="https://user-images.githubusercontent.com/1008395/215327956-3ca10272-4454-4df6-96a4-a12880226157.png" width="300px"/>
