### PR TITLE
fix fediverse link to verify account

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -60,8 +60,8 @@ People interested in our topics are welcome at our regular meetings.
 	<dt>Matrix</dt>
 	<dd>The <a href="https://matrix.to/#/#public_ctreffos:matrix.drpetervoigt.de" rel="noreferer" target="_blank" >public Matrix room</a> is bidirectionally mirrored with the public Jabber MUC.</dd>
 
-	<dt>Mastodon</dt>
-	<dd><a href="https://chaos.social/@chaostreff_osnabrueck">@chaostreff_osnabrueck</a></dd>
+	<dt>Fediverse (Mastodon)</dt>
+	<dd><a rel="me" href="https://chaos.social/@chaostreff_osnabrueck">@chaostreff_osnabrueck</a></dd>
 
 	<dt>Twitter</dt>
 	<dd><a href="https://twitter.com/ctreffos">@ctreffos</a></dd>

--- a/index.html
+++ b/index.html
@@ -63,8 +63,8 @@ Interessierte sind bei unseren regelmäßigen Treffen jederzeit herzlich willkom
 	<dt>Matrix</dt>
 	<dd>Der <a href="https://matrix.to/#/#public_ctreffos:matrix.drpetervoigt.de" rel="noreferer" target="_blank" >öffentliche Matrix-Raum</a> wird mit dem öffentlichen Jabber-MUC bidirektional gespiegelt.
 
-	<dt>Mastodon</dt>
-	<dd><a href="https://chaos.social/@chaostreff_osnabrueck">@chaostreff_osnabrueck</a></dd>
+	<dt>Fediverse (Mastodon)</dt>
+	<dd><a rel="me" href="https://chaos.social/@chaostreff_osnabrueck">@chaostreff_osnabrueck</a></dd>
 
 	<dt>Twitter</dt>
 	<dd><a href="https://twitter.com/ctreffos">@ctreffos</a></dd>


### PR DESCRIPTION
i also clarified that it's an account in the fediverse

that should verify the account (website domain) at https://chaos.social/@chaostreff_osnabrueck